### PR TITLE
Generate JWT file within ./jwttoken directory

### DIFF
--- a/generate-jwt.sh
+++ b/generate-jwt.sh
@@ -1,3 +1,4 @@
 # Borrowed from EthStaker's prepare for the merge guide
 # See https://github.com/remyroy/ethstaker/blob/main/prepare-for-the-merge.md#configuring-a-jwt-token-file
-openssl rand -hex 32 | tr -d "\n" | tee > jwttoken
+mkdir jwttoken
+openssl rand -hex 32 | tr -d "\n" | tee > jwttoken/jwtsecret.hex


### PR DESCRIPTION
I referred a user to your fork but they're struggling because of issues with the JWT token.

It seems that the current code is creating a token at `./jwttoken` and then attempting to mount this file at `/root/jwttoken`, which doesn't work.

See https://www.reddit.com/r/ethstaker/comments/x3wpzf/lighthousedocker_support_invalid_invalidjwtsecret/ for more context.

I'm opening this incomplete PR as the issue tracker is disabled.